### PR TITLE
Bugfix/footer css

### DIFF
--- a/ADAM/app/Resources/views/base.html.twig
+++ b/ADAM/app/Resources/views/base.html.twig
@@ -22,8 +22,9 @@
                 {% block body %}
                 {% endblock %}
             </div>
+            {% include ':default:footer.html.twig' %}
         </div>
-        {% include ':default:footer.html.twig' %}
+        
 
         {% block javascripts %}
         {% endblock %}

--- a/ADAM/app/Resources/views/base.html.twig
+++ b/ADAM/app/Resources/views/base.html.twig
@@ -16,12 +16,17 @@
         <script type="text/javascript" src="{{asset('bundles/front/js/libs/datatables.min.js')}}"></script>
     </head>
     <body>
-        {% include ':default:navbar.html.twig' %}
-        <div class="block-container">
-            {% block body %}{% endblock %}
-            {% block javascripts %}
-            {% endblock %}
-            {% include ':default:footer.html.twig' %}
+        <div id="wrap">
+            {% include ':default:navbar.html.twig' %}
+            <div class="block-container container-fluid">
+                {% block body %}
+                {% endblock %}
+            </div>
         </div>
+        {% include ':default:footer.html.twig' %}
+
+        {% block javascripts %}
+        {% endblock %}
+        {# Bloc JavaScript en fin de page pour plus de rapidité dans le chargement #}
     </body>
 </html>

--- a/ADAM/app/Resources/views/default/footer.html.twig
+++ b/ADAM/app/Resources/views/default/footer.html.twig
@@ -1,21 +1,21 @@
 <footer class="footer-distributed">
     <section id="mainFooter">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-4">
+        <div class="container-fluid">
+            <div class="row-fluid">
+                <div class="col-md-4 col-xs-6">
                     <h3>ADAM</h3>
                     <p>
                         <strong class="letterMiage">A</strong>ssociation <strong class="letterMiage">D</strong>escartes des <strong class="letterMiage">A</strong>nciens <strong class="letterMiage">M</strong>iagistes
                     </p>
                     <p>est une association permettant aux anciennes promotions d'échanger entre elles.</p>
                 </div>
-                <div class="col-md-4">
+                <div class="col-md-4 col-xs-6">
                     <h3>A propos de nous</h3>
                     <ul class="list-unstyled worksList">
                         <li><a href="{{ path('security') }}">Politique de confidentialité</a></li>
                     </ul>
                 </div>
-                <div class="col-md-4">
+                <div class="col-md-4 col-xs-6">
                     <h3>Nous contacter</h3>
                     <address>
                         <p>

--- a/ADAM/src/AppBundle/Resources/views/index.html.twig
+++ b/ADAM/src/AppBundle/Resources/views/index.html.twig
@@ -1,23 +1,24 @@
 {% extends 'base.html.twig' %}
 
 {% block body %}
-	<div class="homepage-background">
-		{# <img class="descartes-background" src="{{ asset('bundles/front/images/saints_peres.jpeg') }}"> #}
-	</div>
-	<div class="homepage-logo col-sm-12">
-		<div class="col-sm-offset-3  col-sm-6">
-			<img class="logo-ADAM" alt="ADAM" src="{{ asset('bundles/front/images/ADAM_Icon.png') }}">
+	<div class="homepage">
+		<div class="homepage-background">
+			{# <img class="descartes-background" src="{{ asset('bundles/front/images/saints_peres.jpeg') }}"> #}
+		</div>
+		<div class="homepage-logo col-sm-12">
+			<div class="col-sm-offset-3  col-sm-6">
+				<img class="logo-ADAM" alt="ADAM" src="{{ asset('bundles/front/images/ADAM_Icon.png') }}">
+			</div>
+		</div>
+
+		<div class="homepage-time col-sm-12">
+		   	<div class="col-sm-offset-3 col-sm-6">
+				<div class="timing">
+					<div id="count-down" data-date="2016-06-31 00:00:00"></div>
+				</div>
+		   </div>
 		</div>
 	</div>
-
-	<div class="homepage-time col-sm-12">
-	   	<div class="col-sm-offset-3 col-sm-6">
-			<div class="timing">
-				<div id="count-down" data-date="2016-06-31 00:00:00"></div>
-			</div>
-	   </div>
-	</div>
-	
 {% endblock %}
 
 {% block stylesheets %}
@@ -28,7 +29,7 @@
 	<script type="text/javascript" src="{{asset('bundles/front/js/libs/TimeCircles.js')}}"></script>
 	<script type="text/javascript">
 	    $("#count-down").TimeCircles(
-	       {   
+	       {
 	           circle_bg_color: "#F3F3F3",
 	           use_background: true,
 	           bg_width: 1.0,

--- a/ADAM/src/AppBundle/Resources/views/index.html.twig
+++ b/ADAM/src/AppBundle/Resources/views/index.html.twig
@@ -1,46 +1,46 @@
 {% extends 'base.html.twig' %}
 
 {% block body %}
-	<div class="homepage">
-		<div class="homepage-background">
-			{# <img class="descartes-background" src="{{ asset('bundles/front/images/saints_peres.jpeg') }}"> #}
-		</div>
-		<div class="homepage-logo col-sm-12">
-			<div class="col-sm-offset-3  col-sm-6">
-				<img class="logo-ADAM" alt="ADAM" src="{{ asset('bundles/front/images/ADAM_Icon.png') }}">
-			</div>
-		</div>
+    <div class="homepage">
+        <div class="homepage-background">
+            {# <img class="descartes-background" src="{{ asset('bundles/front/images/saints_peres.jpeg') }}"> #}
+        </div>
+        <div class="homepage-logo col-sm-12">
+            <div class="col-sm-offset-3  col-sm-6">
+                <img class="logo-ADAM" alt="ADAM" src="{{ asset('bundles/front/images/ADAM_Icon.png') }}">
+            </div>
+        </div>
 
-		<div class="homepage-time col-sm-12">
-		   	<div class="col-sm-offset-3 col-sm-6">
-				<div class="timing">
-					<div id="count-down" data-date="2016-06-31 00:00:00"></div>
-				</div>
-		   </div>
-		</div>
-	</div>
+        <div class="homepage-time col-sm-12">
+            <div class="col-sm-offset-3 col-sm-6">
+                <div class="timing">
+                    <div id="count-down" data-date="2016-06-31 00:00:00"></div>
+                </div>
+           </div>
+        </div>
+    </div>
 {% endblock %}
 
 {% block stylesheets %}
-	<link rel="stylesheet" href="{{ asset('bundles/front/css/libs/TimeCircles.css') }}">
+    <link rel="stylesheet" href="{{ asset('bundles/front/css/libs/TimeCircles.css') }}">
 {% endblock %}
 
 {% block javascripts %}
-	<script type="text/javascript" src="{{asset('bundles/front/js/libs/TimeCircles.js')}}"></script>
-	<script type="text/javascript">
-	    $("#count-down").TimeCircles(
-	       {
-	           circle_bg_color: "#F3F3F3",
-	           use_background: true,
-	           bg_width: 1.0,
-	           fg_width: 0.02,
-	           time: {
-	                Jours: { color: "#BB0F47" },
-	                Heures: { color: "#BB0F47" },
-	                Minutes: { color: "#BB0F47" },
-	                Secondes: { color: "#BB0F47" }
-	            }
-	       }
-	    );
-	</script>
+    <script type="text/javascript" src="{{asset('bundles/front/js/libs/TimeCircles.js')}}"></script>
+    <script type="text/javascript">
+        $("#count-down").TimeCircles(
+           {
+               circle_bg_color: "#F3F3F3",
+               use_background: true,
+               bg_width: 1.0,
+               fg_width: 0.02,
+               time: {
+                    Jours: { color: "#BB0F47" },
+                    Heures: { color: "#BB0F47" },
+                    Minutes: { color: "#BB0F47" },
+                    Secondes: { color: "#BB0F47" }
+                }
+           }
+        );
+    </script>
 {% endblock %}

--- a/ADAM/src/AppBundle/Resources/views/index.html.twig
+++ b/ADAM/src/AppBundle/Resources/views/index.html.twig
@@ -1,23 +1,19 @@
 {% extends 'base.html.twig' %}
 
 {% block body %}
-    <div class="homepage">
-        <div class="homepage-background">
-            {# <img class="descartes-background" src="{{ asset('bundles/front/images/saints_peres.jpeg') }}"> #}
+    <div class="homepage-background"></div>
+    <div class="homepage-logo col-sm-12">
+        <div class="col-sm-offset-3  col-sm-6">
+            <img class="logo-ADAM" alt="ADAM" src="{{ asset('bundles/front/images/ADAM_Icon.png') }}">
         </div>
-        <div class="homepage-logo col-sm-12">
-            <div class="col-sm-offset-3  col-sm-6">
-                <img class="logo-ADAM" alt="ADAM" src="{{ asset('bundles/front/images/ADAM_Icon.png') }}">
-            </div>
-        </div>
+    </div>
 
-        <div class="homepage-time col-sm-12">
-            <div class="col-sm-offset-3 col-sm-6">
-                <div class="timing">
-                    <div id="count-down" data-date="2016-06-31 00:00:00"></div>
-                </div>
-           </div>
-        </div>
+    <div class="homepage-time col-sm-12">
+        <div class="col-sm-offset-3 col-sm-6">
+            <div class="timing">
+                <div id="count-down" data-date="2016-06-31 00:00:00"></div>
+            </div>
+       </div>
     </div>
 {% endblock %}
 

--- a/ADAM/web/bundles/front/css/style.css
+++ b/ADAM/web/bundles/front/css/style.css
@@ -7,17 +7,13 @@
 html,
 body {
     height: 100%;
-    /* The html and body elements cannot have any padding or margin. */
 }
 
-/* Wrapper for page content to push down footer */
 #wrap {
     min-height: 100%;
     height: auto;
-    /* Negative indent footer by its height */
-    margin: 0 auto -150px;
-    /* Pad bottom by footer height */
-    padding: 0 0 150px;
+    margin: 0 auto auto;
+    padding: 0 0 auto;
     background-color: #444444;
 }
 
@@ -38,7 +34,7 @@ nav.navbar {
     margin-bottom: 0;
     border: 0;
     top: 0;
-    height: 54px;
+    height: 54px;   
 }
 
 nav.navbar > .container-fluid {
@@ -192,11 +188,7 @@ nav.navbar > .container-fluid .navbar-nav.navbar-right > li.open a.dropdown-togg
 /*
  * Homepage css
  */
-.homepage {
-    height: 100%;
-}
-
-.homepage .homepage-background {
+.homepage-background {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -205,21 +197,25 @@ nav.navbar > .container-fluid .navbar-nav.navbar-right > li.open a.dropdown-togg
     background-size: cover;
     background-repeat: no-repeat;
     opacity: 0.25;
+    padding: auto;
 }
 
-.homepage .homepage-logo .logo-ADAM {
+.homepage-logo .logo-ADAM {
     height: 300px;
 }
 
-.homepage .homepage-logo {
+.homepage-logo {
     padding-top: 5%;
 }
 
-.homepage .homepage-logo,
-.homepage .homepage-time {
+.homepage-logo,
+.homepage-time {
     text-align: center;
 }
 
+.homepage-time {
+    padding-bottom: 5%;
+}
 /*
  * Registerd list
  */
@@ -248,11 +244,12 @@ nav.navbar > .container-fluid .navbar-nav.navbar-right > li.open a.dropdown-togg
 *  Footer
 */
 .footer-distributed {
-    height: 150px;
-    background-color: var(--descartes-grey-color);
+    background-color: #202020;
+    position: relative;
 }
-.footer-distributed h3{
-    color: var(--descartes-brown-color);
+.footer-distributed h3,
+.footer-distributed p{
+    color: #8C8D90;
 }
 .footer-distributed i, .letterMiage{
     color: var(--descartes-rouge-color);

--- a/ADAM/web/bundles/front/css/style.css
+++ b/ADAM/web/bundles/front/css/style.css
@@ -180,7 +180,11 @@ nav.navbar > .container-fluid .navbar-nav.navbar-right > li.open a.dropdown-togg
 /*
  * Homepage css
  */
-.homepage-background {
+.homepage {
+    height: 100%;
+}
+
+.homepage .homepage-background {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -191,13 +195,16 @@ nav.navbar > .container-fluid .navbar-nav.navbar-right > li.open a.dropdown-togg
     opacity: 0.25;
 }
 
-.homepage-logo .logo-ADAM {
+.homepage .homepage-logo .logo-ADAM {
     height: 300px;
 }
 
-.homepage-logo,
-.homepage-time {
+.homepage .homepage-logo {
     padding-top: 5%;
+}
+
+.homepage .homepage-logo,
+.homepage .homepage-time {
     text-align: center;
 }
 
@@ -230,7 +237,6 @@ nav.navbar > .container-fluid .navbar-nav.navbar-right > li.open a.dropdown-togg
 */
 .footer-distributed {
     position: absolute;
-    bottom: -20%;
     background-color: var(--descartes-grey-color);
     width: 100%;
     margin-top: 0;

--- a/ADAM/web/bundles/front/css/style.css
+++ b/ADAM/web/bundles/front/css/style.css
@@ -4,16 +4,28 @@
   --descartes-brown-color: #554348;
 }
 
+html,
+body {
+    height: 100%;
+    /* The html and body elements cannot have any padding or margin. */
+}
+
+/* Wrapper for page content to push down footer */
+#wrap {
+    min-height: 100%;
+    height: auto;
+    /* Negative indent footer by its height */
+    margin: 0 auto -150px;
+    /* Pad bottom by footer height */
+    padding: 0 0 150px;
+    background-color: #444444;
+}
+
 /*
  * Container block en dessous de la navbar
  */
 .block-container {
-    padding-top: 54px;
-    background-color: #444444;
-    height: 100%;
-    width: 100%;
-    position: fixed;
-    overflow: scroll;
+    padding: 54px 0 0 0;
 }
 
 /*
@@ -236,11 +248,8 @@ nav.navbar > .container-fluid .navbar-nav.navbar-right > li.open a.dropdown-togg
 *  Footer
 */
 .footer-distributed {
-    position: absolute;
+    height: 150px;
     background-color: var(--descartes-grey-color);
-    width: 100%;
-    margin-top: 0;
-    border-top: 0;
 }
 .footer-distributed h3{
     color: var(--descartes-brown-color);

--- a/ADAM/web/bundles/front/css/style.css
+++ b/ADAM/web/bundles/front/css/style.css
@@ -14,7 +14,6 @@
     width: 100%;
     position: fixed;
     overflow: scroll;
-    margin-bottom: 130px;
 }
 
 /*
@@ -229,12 +228,13 @@ nav.navbar > .container-fluid .navbar-nav.navbar-right > li.open a.dropdown-togg
 /*
 *  Footer
 */
-.footer-distributed{
+.footer-distributed {
     position: absolute;
     bottom: -20%;
     background-color: var(--descartes-grey-color);
     width: 100%;
-    height: 136px;
+    margin-top: 0;
+    border-top: 0;
 }
 .footer-distributed h3{
     color: var(--descartes-brown-color);


### PR DESCRIPTION
J'ai réglé le souci où l'opacity débordait jusqu'au footer. Normalement ça marche nickel, j'ai testé sous mac avec changement dans les préférences et j'ai même testé sous mon HP (sous Chrome et Firefox) avec rétrécissement de la fenêtre aussi.

Je me suis permise de changer la couleur du footer. Pour l'instant je préfère que le footer soit sombre pour que le footer reste discret (à défaut d'implémenter mon idée où la première page devait être à 100% mais tant pis). Avec un footer plus sombre les yeux sont moins attiré par le footer (ce qui n'est pas le but) c'est prouvé scientifiquement. 

Idéalement mettre ce fix dans la prod !!!
