### PR TITLE
Fixed footer css

### DIFF
--- a/ADAM/app/Resources/views/base.html.twig
+++ b/ADAM/app/Resources/views/base.html.twig
@@ -22,8 +22,9 @@
                 {% block body %}
                 {% endblock %}
             </div>
+            {% include ':default:footer.html.twig' %}
         </div>
-        {% include ':default:footer.html.twig' %}
+        
 
         {% block javascripts %}
         {% endblock %}

--- a/ADAM/app/Resources/views/base.html.twig
+++ b/ADAM/app/Resources/views/base.html.twig
@@ -21,10 +21,9 @@
             <div class="block-container container-fluid">
                 {% block body %}
                 {% endblock %}
-            </div>
-            {% include ':default:footer.html.twig' %}
+            </div>   
         </div>
-        
+        {% include ':default:footer.html.twig' %}
 
         {% block javascripts %}
         {% endblock %}

--- a/ADAM/src/AppBundle/Resources/views/index.html.twig
+++ b/ADAM/src/AppBundle/Resources/views/index.html.twig
@@ -7,7 +7,6 @@
             <img class="logo-ADAM" alt="ADAM" src="{{ asset('bundles/front/images/ADAM_Icon.png') }}">
         </div>
     </div>
-
     <div class="homepage-time col-sm-12">
         <div class="col-sm-offset-3 col-sm-6">
             <div class="timing">

--- a/ADAM/src/AppBundle/Resources/views/index.html.twig
+++ b/ADAM/src/AppBundle/Resources/views/index.html.twig
@@ -1,23 +1,19 @@
 {% extends 'base.html.twig' %}
 
 {% block body %}
-    <div class="homepage">
-        <div class="homepage-background">
-            {# <img class="descartes-background" src="{{ asset('bundles/front/images/saints_peres.jpeg') }}"> #}
+    <div class="homepage-background"></div>
+    <div class="homepage-logo col-sm-12">
+        <div class="col-sm-offset-3  col-sm-6">
+            <img class="logo-ADAM" alt="ADAM" src="{{ asset('bundles/front/images/ADAM_Icon.png') }}">
         </div>
-        <div class="homepage-logo col-sm-12">
-            <div class="col-sm-offset-3  col-sm-6">
-                <img class="logo-ADAM" alt="ADAM" src="{{ asset('bundles/front/images/ADAM_Icon.png') }}">
-            </div>
-        </div>
+    </div>
 
-        <div class="homepage-time col-sm-12">
-            <div class="col-sm-offset-3 col-sm-6">
-                <div class="timing">
-                    <div id="count-down" data-date="2016-06-31 00:00:00"></div>
-                </div>
-           </div>
-        </div>
+    <div class="homepage-time col-sm-12">
+        <div class="col-sm-offset-3 col-sm-6">
+            <div class="timing">
+                <div id="count-down" data-date="2016-06-31 00:00:00"></div>
+            </div>
+       </div>
     </div>
 {% endblock %}
 

--- a/ADAM/web/bundles/front/css/style.css
+++ b/ADAM/web/bundles/front/css/style.css
@@ -7,17 +7,13 @@
 html,
 body {
     height: 100%;
-    /* The html and body elements cannot have any padding or margin. */
 }
 
-/* Wrapper for page content to push down footer */
 #wrap {
     min-height: 100%;
     height: auto;
-    /* Negative indent footer by its height */
-    margin: 0 auto -150px;
-    /* Pad bottom by footer height */
-    padding: 0 0 150px;
+    margin: 0 auto auto;
+    padding: 0 0 auto;
     background-color: #444444;
 }
 
@@ -38,7 +34,7 @@ nav.navbar {
     margin-bottom: 0;
     border: 0;
     top: 0;
-    height: 54px;
+    height: 54px;   
 }
 
 nav.navbar > .container-fluid {
@@ -192,11 +188,7 @@ nav.navbar > .container-fluid .navbar-nav.navbar-right > li.open a.dropdown-togg
 /*
  * Homepage css
  */
-.homepage {
-    height: 100%;
-}
-
-.homepage .homepage-background {
+.homepage-background {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -205,21 +197,25 @@ nav.navbar > .container-fluid .navbar-nav.navbar-right > li.open a.dropdown-togg
     background-size: cover;
     background-repeat: no-repeat;
     opacity: 0.25;
+    padding: auto;
 }
 
-.homepage .homepage-logo .logo-ADAM {
+.homepage-logo .logo-ADAM {
     height: 300px;
 }
 
-.homepage .homepage-logo {
+.homepage-logo {
     padding-top: 5%;
 }
 
-.homepage .homepage-logo,
-.homepage .homepage-time {
+.homepage-logo,
+.homepage-time {
     text-align: center;
 }
 
+.homepage-time {
+    padding-bottom: 5%;
+}
 /*
  * Registerd list
  */
@@ -248,11 +244,12 @@ nav.navbar > .container-fluid .navbar-nav.navbar-right > li.open a.dropdown-togg
 *  Footer
 */
 .footer-distributed {
-    height: 150px;
-    background-color: var(--descartes-grey-color);
+    background-color: #202020;
+    position: relative;
 }
-.footer-distributed h3{
-    color: var(--descartes-brown-color);
+.footer-distributed h3,
+.footer-distributed p{
+    color: #8C8D90;
 }
 .footer-distributed i, .letterMiage{
     color: var(--descartes-rouge-color);


### PR DESCRIPTION
J'ai réglé le souci où l'opacity débordait jusqu'au footer. Normalement ça marche nickel, j'ai testé sous mac avec changement dans les préférences et j'ai même testé sous mon HP (sous Chrome et Firefox) avec rétrécissement de la fenêtre aussi.

Je me suis permise de changer la couleur du footer. Pour l'instant je préfère que le footer soit sombre pour que le footer reste discret (à défaut d'implémenter mon idée où la première page devait être à 100% mais tant pis). Avec un footer plus sombre les yeux sont moins attiré par le footer (ce qui n'est pas le but) c'est prouvé scientifiquement.

Idéalement mettre ce fix dans la prod !!!
